### PR TITLE
Include docker env variables for cron-job to be able to create the mysql dump.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,8 +3,14 @@
 if ! [ -f backup-cron ]
 then
   echo "Creating cron entry to start backup at: $BACKUP_TIME"
-  echo "$BACKUP_TIME backup
-  " > backup-cron
+  # Note: Must use tabs with indented 'here' scripts.
+  cat <<-EOF >> backup-cron
+	MYSQL_PORT_3306_TCP_ADDR=$MYSQL_PORT_3306_TCP_ADDR
+	MYSQL_ENV_MYSQL_USER=$MYSQL_ENV_MYSQL_USER
+	MYSQL_ENV_MYSQL_DATABASE=$MYSQL_ENV_MYSQL_DATABASE
+	MYSQL_ENV_MYSQL_PASSWORD=$MYSQL_ENV_MYSQL_PASSWORD
+	$BACKUP_TIME backup
+	EOF
   crontab backup-cron
 fi
 


### PR DESCRIPTION
Without the env variables the sql dump generated by the cron job contains
just error message and usage information for mysqldump.
