### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM ubuntu 
+FROM ubuntu
 
 MAINTAINER Angelo Veltens <angelo.veltens@online.de>
 
-RUN apt-get update
-RUN apt-get install mysql-client -y
-
-RUN mkdir /backups
+RUN apt-get update && \
+    apt-get install mysql-client -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /backups
 
 ENV BACKUP_TIME 0 3 * * *
 
-ADD docker-entrypoint.sh /entrypoint.sh
-ADD backup /bin/
-ADD restore /bin/
+COPY docker-entrypoint.sh /entrypoint.sh
+COPY backup restore /bin/
 
 VOLUME /backups
 


### PR DESCRIPTION
- Cleanup apt
- Change `ADD` to `COPY`
  - COPY is recommended over ADD (that has some nasty side-effects)
  - https://docs.docker.com/articles/dockerfile_best-practices/#add-or-copy
- Merge COPYs to `/bin`
