### PR TITLE
Switch to incremental backups

### DIFF
--- a/backup
+++ b/backup
@@ -4,10 +4,12 @@ if [ -z "$MYSQL_ENV_MYSQL_USER" ]; then echo "Error: MYSQL_ENV_MYSQL_USER not se
 if [ -z "$MYSQL_ENV_MYSQL_DATABASE" ]; then echo "Error: MYSQL_ENV_MYSQL_DATABASE not set"; echo "Finished: FAILURE"; exit 1; fi
 if [ -z "$MYSQL_ENV_MYSQL_PASSWORD" ]; then echo "Error: MYSQL_ENV_MYSQL_PASSWORD not set"; echo "Finished: FAILURE"; exit 1; fi
 
+BACKUP_ID=`date '+%Y%m%d-%H%M%S'`
+
 echo 'creating backup archive of /var/www/html'
-tar --create --gzip -vv --directory="/var/www/html/" --file="/backups/backup_`date '+%Y%m%d'`.tar.gz" "./"
+tar --create --gzip -vv --directory="/var/www/html/" --listed-incremental="/backups/.snapshot" --file="/backups/backup_${BACKUP_ID}.tar.gz" "./"
 
 echo 'creating database dump'
-mysqldump -h mysql --add-drop-table -u$MYSQL_ENV_MYSQL_USER -p $MYSQL_ENV_MYSQL_DATABASE --password=$MYSQL_ENV_MYSQL_PASSWORD | bzip2 -c > /backups/backup_`date '+%Y%m%d'`.sql.bz2
+mysqldump -h mysql --add-drop-table -u$MYSQL_ENV_MYSQL_USER -p $MYSQL_ENV_MYSQL_DATABASE --password=$MYSQL_ENV_MYSQL_PASSWORD | bzip2 -c > /backups/backup_${BACKUP_ID}.sql.bz2
 
 echo 'Finished: SUCCESS'

--- a/restore
+++ b/restore
@@ -42,9 +42,13 @@ fi
 echo "deleting files from /var/www/html/"
 rm -R /var/www/html/*
 
-# restore files
+# restore files (incrementally)
 echo "restoring files from $FILES_ARCHIVE to /var/www/html"
-tar -xzf $FILES_ARCHIVE --directory="/var/www/html/"
+ALL_FILES_ARCHIVES="`ls -1 /backups/*.tar.gz | sort`"
+for F in $ALL_FILES_ARCHIVES; do
+    tar --listed-incremental=/dev/null -xzf $F --directory="/var/www/html/"
+    if [ $F = $FILES_ARCHIVE ]; then break; fi
+done
 
 # update wp-config.php
 sed -i s/"define('DB_NAME', '.*');"/"define('DB_NAME', '$MYSQL_ENV_MYSQL_DATABASE');"/g /var/www/html/wp-config.php


### PR DESCRIPTION
Implemented using `tar --listed-incremental`
(http://www.unixmen.com/performing-incremental-backups-using-tar/)

Important changes imposed by this feature:

1 - Backups are now timestamped at the second.

Why? Because it shouldn't be possible to override an existing
backup file with a new one (loosing 1 backup in the history and you
loose data).

So if someone makes multiple backups per day (by cron or by running
`backup` manually), he won't override any backup.

2 - Migration requires the whole set of tar files.

Because restoring is now done by untaring the whole history of backups
one by one, the user needs to migrate the whole backup folder.
