### PR TITLE
Add --single-transaction --column-statistics=0 to avoid errors on mysqldump

### DIFF
--- a/src/backup
+++ b/src/backup
@@ -19,6 +19,6 @@ echo 'creating backup archive of /var/www/html'
 tar --create --gzip -vv --directory="/var/www/html/" --file="/backups/backup_`date '+%Y%m%d'`.tar.gz" "./"
 
 echo 'creating database dump'
-mysqldump --host="${MYSQL_ENV_MYSQL_HOST}" --add-drop-table --user="${MYSQL_ENV_MYSQL_USER}" --password="${MYSQL_ENV_MYSQL_PASSWORD}" "${MYSQL_ENV_MYSQL_DATABASE}" | bzip2 -c > "/backups/backup_`date '+%Y%m%d'`.sql.bz2"
+mysqldump --host="${MYSQL_ENV_MYSQL_HOST}" --add-drop-table --user="${MYSQL_ENV_MYSQL_USER}" --password="${MYSQL_ENV_MYSQL_PASSWORD}" "${MYSQL_ENV_MYSQL_DATABASE}" --single-transaction --column-statistics=0 | bzip2 -c > "/backups/backup_`date '+%Y%m%d'`.sql.bz2"
 
 echo 'Finished: SUCCESS'


### PR DESCRIPTION
I've tried to setup wordpress-backup, but encountered two connection problems, which I've tried to address with this pull request.

First, I encountered an  `1045: Access denied` error, and the fix included in this pull request is to add a `--single-transaction` argument to `mysqldump`, as explained here:
https://stackoverflow.com/questions/20059823/mysqldump-error-1045-access-denied-despite-correct-passwords-etc

Second, I encountered the error `Unknown table 'COLUMN_STATISTICS' in information_schema (1109)` during execution of ` mysqldump`, which seems to be solvable by adding the  argument `--column-statistics=0` as explained here:
https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109