### PR TITLE
Try to fix sed error

### DIFF
--- a/src/restore
+++ b/src/restore
@@ -49,10 +49,10 @@ echo "restoring files from $FILES_ARCHIVE to /var/www/html"
 tar -xzf "${FILES_ARCHIVE}" --directory="/var/www/html/"
 
 # update wp-config.php
-sed -i s/"define('DB_NAME', '.*');"/"define('DB_NAME', '$MYSQL_ENV_MYSQL_DATABASE');"/g /var/www/html/wp-config.php
-sed -i s/"define('DB_USER', '.*');"/"define('DB_USER', '$MYSQL_ENV_MYSQL_USER');"/g /var/www/html/wp-config.php
-sed -i s/"define('DB_PASSWORD', '.*');"/"define('DB_PASSWORD', '$MYSQL_ENV_MYSQL_PASSWORD');"/g /var/www/html/wp-config.php
-sed -i s/"define('DB_HOST', '.*');"/"define('DB_HOST', '$MYSQL_ENV_MYSQL_HOST:$MYSQL_PORT_3306_TCP_PORT');"/g /var/www/html/wp-config.php
+sed -i s|"define('DB_NAME', '.*');"/"define('DB_NAME', '$MYSQL_ENV_MYSQL_DATABASE');"|g /var/www/html/wp-config.php
+sed -i s|"define('DB_USER', '.*');"/"define('DB_USER', '$MYSQL_ENV_MYSQL_USER');"|g /var/www/html/wp-config.php
+sed -i s|"define('DB_PASSWORD', '.*');"/"define('DB_PASSWORD', '$MYSQL_ENV_MYSQL_PASSWORD');"|g /var/www/html/wp-config.php
+sed -i s|"define('DB_HOST', '.*');"/"define('DB_HOST', '$MYSQL_ENV_MYSQL_HOST:$MYSQL_PORT_3306_TCP_PORT');"|g /var/www/html/wp-config.php
 
 # set correct file owner
 chown -R www-data:www-data /var/www/html


### PR DESCRIPTION
Try to fix: 
```sed: -i expression #1, char 63: unknown option to `s’```

The message shows when i run : docker exec [Container_name] restore [Ver.]
```
deleting files from /var/www/html/
restoring files from /backups/backup_0.tar.gz to /var/www/html
sed: -e expression #1, char 63: unknown option to `s'
```

And i found someone modify "/" to "|":
https://services.pfem.clermont.inra.fr/gitlab/fgiacomoni/metabolomics-fragment-annotation/-/commit/c8d8a64b7d39f12fef349976d64fa556dd55e683