### PR TITLE
Support secrets

### DIFF
--- a/src/backup
+++ b/src/backup
@@ -2,6 +2,46 @@
 set -e
 set -o pipefail
 
+backup_log() {
+	local type="$1"; shift
+	printf '%s [%s] [Entrypoint]: %s\n' "$(date --rfc-3339=seconds)" "$type" "$*"
+}
+
+backup_error() {
+	backup_log ERROR "$@" >&2
+	exit 1
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		backup_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+docker_setup_env() {
+	file_env 'MYSQL_ENV_MYSQL_HOST' '%'
+	file_env 'MYSQL_ENV_MYSQL_USER'
+	file_env 'MYSQL_ENV_MYSQL_DATABASE'
+	file_env 'MYSQL_ENV_MYSQL_PASSWORD'
+}
+
+docker_setup_env;
+
 cleanup() {
   echo "Cleanup backup older than $CLEANUP_OLDER_THAN days"
   toberemove=$(find /backups/ -type f -not -name ".*" -mtime +$CLEANUP_OLDER_THAN | wc -l)

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+backup_log() {
+	local type="$1"; shift
+	printf '%s [%s] [Entrypoint]: %s\n' "$(date --rfc-3339=seconds)" "$type" "$*"
+}
+
+backup_error() {
+	mysql_log ERROR "$@" >&2
+	exit 1
+}
+
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
@@ -9,7 +19,7 @@ file_env() {
 	local fileVar="${var}_FILE"
 	local def="${2:-}"
 	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
-		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+		backup_error "Both $var and $fileVar are set (but are exclusive)"
 	fi
 	local val="$def"
 	if [ "${!var:-}" ]; then
@@ -26,7 +36,7 @@ then
   echo "Creating cron entry to start backup at: $BACKUP_TIME"
   # Note: Must use tabs with indented 'here' scripts.
   cat <<-EOF >> backup-cron
-file_env 'MYSQL_ENV_MYSQL_HOST'
+file_env 'MYSQL_ENV_MYSQL_HOST' '%'
 file_env 'MYSQL_ENV_MYSQL_USER'
 file_env 'MYSQL_ENV_MYSQL_DATABASE'
 file_env 'MYSQL_ENV_MYSQL_PASSWORD'

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -1,14 +1,35 @@
 #!/bin/bash
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 if ! [ -f backup-cron ]
 then
   echo "Creating cron entry to start backup at: $BACKUP_TIME"
   # Note: Must use tabs with indented 'here' scripts.
   cat <<-EOF >> backup-cron
-MYSQL_ENV_MYSQL_HOST=$MYSQL_ENV_MYSQL_HOST
-MYSQL_ENV_MYSQL_USER=$MYSQL_ENV_MYSQL_USER
-MYSQL_ENV_MYSQL_DATABASE=$MYSQL_ENV_MYSQL_DATABASE
-MYSQL_ENV_MYSQL_PASSWORD=$MYSQL_ENV_MYSQL_PASSWORD
+file_env 'MYSQL_ENV_MYSQL_HOST'
+file_env 'MYSQL_ENV_MYSQL_USER'
+file_env 'MYSQL_ENV_MYSQL_DATABASE'
+file_env 'MYSQL_ENV_MYSQL_PASSWORD'
 EOF
 
   if [[ $CLEANUP_OLDER_THAN ]]

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -31,15 +31,24 @@ file_env() {
 	unset "$fileVar"
 }
 
+docker_setup_env() {
+	file_env 'MYSQL_ENV_MYSQL_HOST' '%'
+	file_env 'MYSQL_ENV_MYSQL_USER'
+	file_env 'MYSQL_ENV_MYSQL_DATABASE'
+	file_env 'MYSQL_ENV_MYSQL_PASSWORD'
+}
+
+docker_setup_env;
+
 if ! [ -f backup-cron ]
 then
   echo "Creating cron entry to start backup at: $BACKUP_TIME"
   # Note: Must use tabs with indented 'here' scripts.
   cat <<-EOF >> backup-cron
-file_env 'MYSQL_ENV_MYSQL_HOST' '%'
-file_env 'MYSQL_ENV_MYSQL_USER'
-file_env 'MYSQL_ENV_MYSQL_DATABASE'
-file_env 'MYSQL_ENV_MYSQL_PASSWORD'
+MYSQL_ENV_MYSQL_HOST=$MYSQL_ENV_MYSQL_HOST
+MYSQL_ENV_MYSQL_USER=$MYSQL_ENV_MYSQL_USER
+MYSQL_ENV_MYSQL_DATABASE=$MYSQL_ENV_MYSQL_DATABASE
+MYSQL_ENV_MYSQL_PASSWORD=$MYSQL_ENV_MYSQL_PASSWORD
 EOF
 
   if [[ $CLEANUP_OLDER_THAN ]]

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -6,7 +6,7 @@ backup_log() {
 }
 
 backup_error() {
-	mysql_log ERROR "$@" >&2
+	backup_log ERROR "$@" >&2
 	exit 1
 }
 

--- a/src/restore
+++ b/src/restore
@@ -1,6 +1,46 @@
 #!/bin/bash
 set -e
 
+backup_log() {
+	local type="$1"; shift
+	printf '%s [%s] [Entrypoint]: %s\n' "$(date --rfc-3339=seconds)" "$type" "$*"
+}
+
+backup_error() {
+	backup_log ERROR "$@" >&2
+	exit 1
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		backup_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+docker_setup_env() {
+	file_env 'MYSQL_ENV_MYSQL_HOST' '%'
+	file_env 'MYSQL_ENV_MYSQL_USER'
+	file_env 'MYSQL_ENV_MYSQL_DATABASE'
+	file_env 'MYSQL_ENV_MYSQL_PASSWORD'
+}
+
+docker_setup_env;
+
 if ! [[ "$1" ]]
 then
     echo "Error: Backup name missing"


### PR DESCRIPTION
I noticed this fork from @moracabanas  where changes have been made to support reading the passwords from files (to allow for docker secret files to be used) Would you consider integrating these changes? It would close #35